### PR TITLE
サブネットのoutputフォーマットを変更

### DIFF
--- a/modules/vpc/outputs.tf
+++ b/modules/vpc/outputs.tf
@@ -11,12 +11,12 @@ output "vpc_name" {
 
 output "public_subnets" {
   description  = "パブリックサブネットの情報です"
-  value = {for subnet in aws_subnet.public_subnets : subnet.availability_zone => merge({ id = subnet.id }, subnet.tags)}
+  value = {for subnet in aws_subnet.public_subnets : subnet.availability_zone => merge(subnet.tags, {id = subnet.id })}
 }
 
 output "private_subnets" {
   description = "プライベートサブネットの情報です"
-  value = {for subnet in aws_subnet.private_subnets : subnet.availability_zone => merge({ id = subnet.id }, subnet.tags) }
+  value = {for subnet in aws_subnet.private_subnets : subnet.availability_zone => merge(subnet.tags, {id = subnet.id })}
 }
 
 output "public_route_tables" {

--- a/modules/vpc/outputs.tf
+++ b/modules/vpc/outputs.tf
@@ -11,12 +11,12 @@ output "vpc_name" {
 
 output "public_subnets" {
   description  = "パブリックサブネットの情報です"
-  value = {for subnet in aws_subnet.public_subnets : subnet.availability_zone => subnet.id }
+  value = {for subnet in aws_subnet.public_subnets : subnet.availability_zone => merge({ id = subnet.id }, subnet.tags)}
 }
 
 output "private_subnets" {
   description = "プライベートサブネットの情報です"
-  value = {for subnet in aws_subnet.private_subnets : subnet.availability_zone => subnet.id }
+  value = {for subnet in aws_subnet.private_subnets : subnet.availability_zone => merge({ id = subnet.id }, subnet.tags) }
 }
 
 output "public_route_tables" {


### PR DESCRIPTION
サブネットのoutputフォーマットを以下の通り変更しました。

+ 変更前
```
public_subnets = {
  "AZ名" = "サブネットID"
}
```

+ 変更後

```
public_subnets = {
  "AZ名" = {
     "id" = "サブネットID"
    "サブネットのタグ1" = "サブネットのタグの値1"
    "サブネットのタグ2" = "サブネットのタグの値2"
    ...
    "サブネットのタグN" = "サブネットのタグの値N"
  }
}
```